### PR TITLE
Correct Ubooquity development status

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,7 @@ work in progress.
 
 In December 2021, following a request by a Komga user to enhance the OPDS feed, gotson decided to make some changes to
 the OPDS Page Streaming Extension. The 1.0 specification was written in 2014 for Ubooquity, but is now used by many
-applications. Ubooquity was already inactive for a couple of years, so changing the specification would mean publish it
+applications. Ubooquity having been dormant for a couple of years, changing the specification would mean publish it
 somewhere. gotson already had a mirror of the 1.0 specification, in case the original page would suddenly go down.
 That's when the idea came to bring the OPDS PSE specification under the Anansi Project.
 

--- a/docs/opds-pse/intro.md
+++ b/docs/opds-pse/intro.md
@@ -13,8 +13,7 @@ for the book to be completely downloaded.
 
 ## History
 
-Recently more applications started implementing the extension, with more features than Ubooquity had. Ubooquity is not
-being actively developed anymore, but the OPDS Page Streaming Extension still needed to evolve.
+Recently more applications started implementing the extension, with more features than Ubooquity had.
 
 We decided to bring the OPDS Page Streaming Extension under the umbrella of the Anansi Project, in order to add more
 features to the specification. We created a GitHub repository to host the different versions of the specification, and


### PR DESCRIPTION
Hello,

although not seeing new realease for a few years (ok, five), Ubooquity never stopped being developped.
Version 3 [was just released](https://vaemendis.net/ubooquity/article23/ubooquity-3-beta). 

I'd appreciate if the doc did not mention its death anymore. 

Thanks. :)